### PR TITLE
Add build script

### DIFF
--- a/scripts/build-vs-x64.bat
+++ b/scripts/build-vs-x64.bat
@@ -1,0 +1,1 @@
+@call %~dp0build-vs.bat x64

--- a/scripts/build-vs-x86.bat
+++ b/scripts/build-vs-x86.bat
@@ -1,0 +1,1 @@
+@call %~dp0build-vs.bat x86

--- a/scripts/build-vs.bat
+++ b/scripts/build-vs.bat
@@ -1,0 +1,38 @@
+@echo off
+setlocal enabledelayedexpansion
+set /a errorno=1
+for /F "delims=#" %%E in ('"prompt #$E# & for %%E in (1) do rem"') do set "_ESC=%%E"
+
+set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%vswhere%" (
+  echo Failed to find "vswhere.exe".  Please install the latest version of Visual Studio.
+  goto :ERROR
+)
+
+set "vsdir="
+for /f "usebackq tokens=*" %%i in (
+  `"%vswhere%" -latest ^
+               -products * ^
+               -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 ^
+               -property installationPath`
+) do (
+  set "vsdir=%%i"
+)
+if "%vsdir%" == "" (
+  echo Failed to find Visual C++.  Please install the latest version of Visual C++.
+  goto :ERROR
+)
+
+call "%vsdir%\VC\Auxiliary\Build\vcvarsall.bat" %* || goto :ERROR
+
+nmake /f NtTrace.mak || goto :ERROR
+
+echo %_ESC%[2K %~n0 : Status =%_ESC%[92m OK %_ESC%[0m
+set /a errorno=0
+goto :END
+
+:ERROR
+echo %_ESC%[2K %~n0 : Status =%_ESC%[92m ERROR %_ESC%[0m
+
+:END
+exit /B %errorno%


### PR DESCRIPTION
Hi,  thanks for this very useful utility!

This PR adds trivial build scripts for x64 and x86.

They can be invoked by the following commands:

```
cmd.exe
cd /d PATH\TO\NtTrace
.\scripts\build-vs-x64.bat
.\scripts\build-vs-x86.bat
```

You can test this PR with the following commands:

```cmd
cmd.exe
cd /d "%PUBLIC%\Documents"
git clone https://github.com/rogerorr/NtTrace.git NtTrace-PR11
cd NtTrace-PR11

git pull origin pull/11/head
git log -1

.\scripts\build-vs-x64.bat
.\NtTrace.exe .\NtTrace.exe > nt-trace-x64.log

.\scripts\build-vs-x86.bat
.\NtTrace.exe .\NtTrace.exe > nt-trace-x86.log
```
